### PR TITLE
ignore autogen backup configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 /.jshintrc
+/.settings-schema-backup.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 /.jshintrc
-/.settings-schema-backup.json
+/settings-schema-backup.json

--- a/applet.js
+++ b/applet.js
@@ -57,7 +57,7 @@ if (typeof require !== 'undefined') {
   fuzzyOptions = constants.fuzzyOptions;
   gridWidths = constants.gridWidths;
 } else {
-  const AppletDir = imports.ui.appletManager.applets['Cinnamenu@json'];
+  const AppletDir = imports.ui.appletManager.applets[constants.APPLET_UUID];
   let storeVersion = typeof Symbol === 'undefined' ? 'store_mozjs24' : 'store';
   store = AppletDir[storeVersion];
   fuzzy = AppletDir.fuzzy.fuzzy;

--- a/buttons.js
+++ b/buttons.js
@@ -27,7 +27,7 @@ if (typeof require !== 'undefined') {
   _ = constants._;
   ApplicationType = constants.ApplicationType;
 } else {
-  const AppletDir = imports.ui.appletManager.applets['Cinnamenu@json'];
+  const AppletDir = imports.ui.appletManager.applets[constants.APPLET_UUID];
   let storeVersion = typeof Symbol === 'undefined' ? 'store_mozjs24' : 'store';
   store = AppletDir[storeVersion];
   setTimeout = AppletDir.utils.setTimeout;

--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,5 @@
+const APPLET_UUID = "Cinnamenu@json"
+
 // l10n
 const Gettext = imports.gettext;
 
@@ -6,7 +8,7 @@ function _(str) {
   if (cinnamonTranslation !== str) {
     return cinnamonTranslation;
   }
-  return Gettext.dgettext('Cinnamenu@json', str);
+  return Gettext.dgettext(APPLET_UUID, str);
 }
 
 const REMEMBER_RECENT_KEY = 'remember-recent-files';


### PR DESCRIPTION
Cinnamon on Debian creates an automatic backup of configuration files - versus deleting it each time settings are updated, it is easier to exclude it.